### PR TITLE
Reimplement auto-follow feature with UI controls and state management

### DIFF
--- a/doc/test-state-storage.md
+++ b/doc/test-state-storage.md
@@ -5,9 +5,9 @@
 插件继续采用双存储策略，但运行态图状态的结构已重新设计为带版本号的语义化对象：
 
 - `graph-enhance-config`: 保留现有用户设置
-- `graph-enhance-graph-state`: 持久化图视图运行态状态
+- `graph-enhance-graph-state`: 持久化图视图运行态状态，包括 dock 里的即时开关
 
-这次重构不包含旧状态数据迁移，因为该结构尚未正式上线。
+这次重构不包含旧 `graph-enhance-config.autoFollow` 的兼容迁移；`autoFollow` 在运行态状态中默认开启，旧设置键只在启动时被清理。
 
 ## 新状态结构
 
@@ -19,6 +19,7 @@ interface GraphPersistedState {
    };
    filters: {
       hideDailyNotes: boolean;
+      autoFollow: boolean;
    };
 }
 ```
@@ -28,7 +29,8 @@ interface GraphPersistedState {
 1. `version` 为未来升级逻辑预留入口。
 2. `view.mode` 明确表示当前图展示模式，比 `graphType` 更符合持久化语义。
 3. `filters.hideDailyNotes` 明确表示过滤条件，比 `isHideDailynote` 更清晰。
-4. 后续如需保存节点位置，建议增加 `layout.nodePositions`，而不是继续在根对象追加扁平字段。
+4. `filters.autoFollow` 归类到 dock 运行态过滤/跟随开关，避免继续放在静态设置存储里。
+5. 后续如需保存节点位置，建议增加 `layout.nodePositions`，而不是继续在根对象追加扁平字段。
 
 ## 实现范围
 
@@ -37,13 +39,14 @@ interface GraphPersistedState {
 1. 新状态存储 key 设计。
 2. 状态对象版本号设计。
 3. 当前已持久化字段的语义化重命名。
-4. 统一的状态标准化逻辑，确保读取时总能得到完整默认值。
+4. `autoFollow` 从设置存储迁移到运行态状态。
+5. 统一的状态标准化逻辑，确保读取时总能得到完整默认值。
 
 ### 未包含
 
 1. 旧 `graph-enhance-state` 到新结构的迁移逻辑。
 2. 节点位置持久化实现。
-3. 设置存储 `graph-enhance-config` 的结构调整。
+3. 除 `autoFollow` 之外的设置存储 `graph-enhance-config` 结构调整。
 
 ## 后续扩展建议
 
@@ -57,6 +60,7 @@ interface GraphPersistedState {
    };
    filters: {
       hideDailyNotes: boolean;
+      autoFollow: boolean;
    };
    layout?: {
       nodePositions?: Record<string, { x: number; y: number }>;

--- a/src/__tests__/dock.test.ts
+++ b/src/__tests__/dock.test.ts
@@ -4,13 +4,20 @@ import { JSDOM } from "jsdom";
 const setIsHideDailynote = vi.fn();
 const setGraphType = vi.fn();
 const initEChart = vi.fn();
+const saveAutoFollowFilter = vi.fn((value: boolean) => {
+    savedAutoFollow = value;
+});
 const saveHideDailyNotesFilter = vi.fn((value: boolean) => {
     savedHideDailyNotes = value;
 });
 const savePersistedGraphViewMode = vi.fn();
 
+let savedAutoFollow = true;
 let savedHideDailyNotes = true;
 let dockInit: (() => void) | undefined;
+let dockResize: (() => void) | undefined;
+const eventBusOn = vi.fn();
+const eventBusOff = vi.fn();
 
 vi.mock("../graph", () => ({
     Display: vi.fn(),
@@ -34,6 +41,8 @@ vi.mock("siyuan", () => ({
 vi.mock("../utils", () => ({
     i18n: {
         pluginName: "Enhanced Graph",
+        dockBtnEnableAutoFollow: "Enable Auto Follow",
+        dockBtnDisableAutoFollow: "Disable Auto Follow",
         dockBtnHideDN: "Hide DailyNote",
         dockBtnShowDN: "Show DailyNote",
         dockBtnPath: "Path Graph",
@@ -47,22 +56,21 @@ vi.mock("../utils", () => ({
         dockBtnExitFullscreen: "Exit Fullscreen",
     },
     plugin: {
-        addDock: vi.fn(({ init }: { init: () => void }) => {
+        addDock: vi.fn(({ init, resize }: { init: () => void; resize: () => void }) => {
             dockInit = init;
+            dockResize = resize;
         }),
         loadData: vi.fn(() => Promise.resolve()),
-        eventBus: { on: vi.fn(), off: vi.fn() },
+        eventBus: { on: eventBusOn, off: eventBusOff },
     },
     rawGraph: undefined,
+    getAutoFollowFilter: vi.fn(() => savedAutoFollow),
     getPersistedGraphViewMode: vi.fn(() => "ancestor"),
+    saveAutoFollowFilter,
     savePersistedGraphViewMode,
     getHideDailyNotesFilter: vi.fn(() => savedHideDailyNotes),
     saveHideDailyNotesFilter,
     GRAPH_STATE_STORAGE_NAME: "graph-enhance-graph-state",
-}));
-
-vi.mock("../settings", () => ({
-    getSetting: vi.fn(() => "false"),
 }));
 
 vi.mock("../renderer", () => ({
@@ -81,8 +89,10 @@ describe("dock", () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        savedAutoFollow = true;
         savedHideDailyNotes = true;
         dockInit = undefined;
+        dockResize = undefined;
 
         dom = new JSDOM("<body></body>");
         Object.defineProperty(globalThis, "window", {
@@ -99,25 +109,45 @@ describe("dock", () => {
         });
     });
 
+    function mountDock() {
+        const element = document.createElement("div");
+        document.body.appendChild(element);
+        dockInit?.call({ element });
+        return element;
+    }
+
+    function setContainerSize(width: number, height: number) {
+        const container = document.getElementById("graph_enhance_container");
+        Object.defineProperty(container, "offsetWidth", {
+            value: width,
+            configurable: true,
+        });
+        Object.defineProperty(container, "offsetHeight", {
+            value: height,
+            configurable: true,
+        });
+    }
+
     afterEach(() => {
         dom.window.close();
     });
 
-    it("restores persisted hidden dailynote state on dock init", async () => {
+    it("restores persisted hidden dailynote and auto follow state on dock init", async () => {
         const { initDock } = await import("../dock");
 
         initDock();
 
-        const element = document.createElement("div");
-        document.body.appendChild(element);
-        dockInit?.call({ element });
+        mountDock();
         await Promise.resolve();
 
         expect(setGraphType).toHaveBeenCalledWith("ancestor");
         expect(setIsHideDailynote).toHaveBeenCalledWith(true);
         expect(initEChart).toHaveBeenCalledTimes(1);
+        expect(document.getElementById("graph_enhance_autofollow")?.getAttribute("aria-label")).toBe("Disable Auto Follow");
+        expect(document.getElementById("graph_enhance_autofollow_icon")?.classList.contains("plugin-sample__dock-icon--active")).toBe(true);
         expect(document.getElementById("graph_enhance_dailynote")?.getAttribute("aria-label")).toBe("Show DailyNote");
         expect(document.getElementById("graph_enhance_dailynote_icon")?.classList.contains("plugin-sample__dock-icon--active")).toBe(false);
+        expect(document.querySelectorAll(".plugin-sample__dock-divider")).toHaveLength(2);
     });
 
     it("persists the daily note filter with the semantic state helper", async () => {
@@ -125,9 +155,7 @@ describe("dock", () => {
 
         initDock();
 
-        const element = document.createElement("div");
-        document.body.appendChild(element);
-        dockInit?.call({ element });
+        mountDock();
         await Promise.resolve();
 
         await document.getElementById("graph_enhance_dailynote")?.onclick?.(new dom.window.MouseEvent("click") as any);
@@ -135,14 +163,31 @@ describe("dock", () => {
         expect(saveHideDailyNotesFilter).toHaveBeenCalledWith(false);
     });
 
+    it("persists auto follow with the semantic state helper and registers listener when visible", async () => {
+        const { initDock, autoFollow } = await import("../dock");
+
+        savedAutoFollow = false;
+        initDock();
+
+        mountDock();
+        setContainerSize(320, 240);
+        dockResize?.call({});
+        await Promise.resolve();
+
+        await document.getElementById("graph_enhance_autofollow")?.onclick?.(new dom.window.MouseEvent("click") as any);
+
+        expect(saveAutoFollowFilter).toHaveBeenCalledWith(true);
+        expect(eventBusOff).toHaveBeenCalledWith("switch-protyle", autoFollow);
+        expect(eventBusOn).toHaveBeenCalledWith("switch-protyle", autoFollow);
+        expect(document.getElementById("graph_enhance_autofollow")?.getAttribute("aria-label")).toBe("Disable Auto Follow");
+    });
+
     it("persists the graph view mode with the semantic state helper", async () => {
         const { initDock } = await import("../dock");
 
         initDock();
 
-        const element = document.createElement("div");
-        document.body.appendChild(element);
-        dockInit?.call({ element });
+        mountDock();
         await Promise.resolve();
 
         await document.getElementById("graph_enhance_global")?.onclick?.(new dom.window.MouseEvent("click") as any);

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+
+const initDock = vi.fn();
+const settingInit = vi.fn();
+
+vi.mock("../dock", () => ({
+    initDock,
+}));
+
+vi.mock("../settings", () => ({
+    DEFAULT_SETTINGS: {
+        rankdir: "LR",
+        ranker: "network-simplex",
+        nodesMaximum: "200",
+        neighborDepth: "2",
+        nodesExclusion: "",
+        font: "system-ui",
+        fontSize: "12",
+    },
+    settingInit,
+}));
+
+vi.mock("../index.scss", () => ({}));
+
+vi.mock("siyuan", () => ({
+    Plugin: class {
+        data = {
+            "graph-enhance-config": {
+                autoFollow: "false",
+                rankdir: "RL",
+                nodesMaximum: "300",
+            },
+            "graph-enhance-graph-state": {
+                version: 1,
+                view: { mode: "global" },
+                filters: { hideDailyNotes: true },
+            },
+        };
+
+        addIcons = vi.fn();
+        loadData = vi.fn(async () => undefined);
+        saveData = vi.fn((key: string, value: unknown) => {
+            this.data[key] = value;
+        });
+        removeData = vi.fn(async () => undefined);
+    },
+}));
+
+describe("plugin startup", () => {
+    it("defaults autoFollow on in graph runtime state and removes the legacy settings key", async () => {
+        const { default: GraphEnhancePlugin } = await import("../index");
+
+        const plugin = new GraphEnhancePlugin();
+        await plugin.onload();
+
+        expect(plugin.saveData).toHaveBeenNthCalledWith(1, "graph-enhance-config", {
+            rankdir: "RL",
+            ranker: "network-simplex",
+            nodesMaximum: "300",
+            neighborDepth: "2",
+            nodesExclusion: "",
+            font: "system-ui",
+            fontSize: "12",
+        });
+        expect(plugin.saveData).toHaveBeenNthCalledWith(2, "graph-enhance-graph-state", {
+            version: 1,
+            view: { mode: "global" },
+            filters: { hideDailyNotes: true, autoFollow: true },
+        });
+        expect(initDock).toHaveBeenCalledTimes(1);
+        expect(settingInit).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+    getAutoFollowFilter,
     createDefaultGraphPersistedState,
     GRAPH_STATE_STORAGE_NAME,
     getGraphPersistedState,
@@ -8,6 +9,7 @@ import {
     getPersistedGraphViewMode,
     getThemeMode,
     normalizeGraphPersistedState,
+    saveAutoFollowFilter,
     saveGraphPersistedState,
     saveHideDailyNotesFilter,
     savePersistedGraphViewMode,
@@ -49,7 +51,7 @@ describe("utils/getThemeMode test suite", () => {
         expect(createDefaultGraphPersistedState()).toEqual({
             version: 1,
             view: { mode: "ancestor" },
-            filters: { hideDailyNotes: false },
+            filters: { hideDailyNotes: false, autoFollow: true },
         });
     });
 
@@ -59,7 +61,7 @@ describe("utils/getThemeMode test suite", () => {
         })).toEqual({
             version: 1,
             view: { mode: "ancestor" },
-            filters: { hideDailyNotes: true },
+            filters: { hideDailyNotes: true, autoFollow: true },
         });
     });
 
@@ -77,10 +79,11 @@ describe("utils/getThemeMode test suite", () => {
         expect(getGraphPersistedState()).toEqual({
             version: 1,
             view: { mode: "global" },
-            filters: { hideDailyNotes: false },
+            filters: { hideDailyNotes: false, autoFollow: true },
         });
         expect(getPersistedGraphViewMode()).toBe("global");
         expect(getHideDailyNotesFilter()).toBe(false);
+        expect(getAutoFollowFilter()).toBe(true);
     });
 
     it("saves merged persisted graph state patches", () => {
@@ -89,7 +92,7 @@ describe("utils/getThemeMode test suite", () => {
                 [GRAPH_STATE_STORAGE_NAME]: {
                     version: 1,
                     view: { mode: "ancestor" },
-                    filters: { hideDailyNotes: false },
+                    filters: { hideDailyNotes: false, autoFollow: true },
                 },
             },
             i18n: {},
@@ -103,23 +106,29 @@ describe("utils/getThemeMode test suite", () => {
         expect(saveData).toHaveBeenCalledWith(GRAPH_STATE_STORAGE_NAME, {
             version: 1,
             view: { mode: "ancestor" },
-            filters: { hideDailyNotes: true },
+            filters: { hideDailyNotes: true, autoFollow: true },
         });
     });
 
-    it("saves semantic view mode and daily note filter helpers", () => {
+    it("saves semantic view mode and filter helpers", () => {
         savePersistedGraphViewMode("path");
         saveHideDailyNotesFilter(true);
+        saveAutoFollowFilter(false);
 
         expect(saveData).toHaveBeenNthCalledWith(1, GRAPH_STATE_STORAGE_NAME, {
             version: 1,
             view: { mode: "path" },
-            filters: { hideDailyNotes: false },
+            filters: { hideDailyNotes: false, autoFollow: true },
         });
         expect(saveData).toHaveBeenNthCalledWith(2, GRAPH_STATE_STORAGE_NAME, {
             version: 1,
             view: { mode: "ancestor" },
-            filters: { hideDailyNotes: true },
+            filters: { hideDailyNotes: true, autoFollow: true },
+        });
+        expect(saveData).toHaveBeenNthCalledWith(3, GRAPH_STATE_STORAGE_NAME, {
+            version: 1,
+            view: { mode: "ancestor" },
+            filters: { hideDailyNotes: false, autoFollow: false },
         });
     });
 });

--- a/src/dock.ts
+++ b/src/dock.ts
@@ -1,9 +1,18 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Display, initRawGraph, setGraphType, setIsHideDailynote, setSourceNode } from "./graph";
-import { getHideDailyNotesFilter, getPersistedGraphViewMode, i18n, plugin, rawGraph, saveHideDailyNotesFilter, savePersistedGraphViewMode } from "./utils";
+import {
+    getAutoFollowFilter,
+    getHideDailyNotesFilter,
+    getPersistedGraphViewMode,
+    i18n,
+    plugin,
+    rawGraph,
+    saveAutoFollowFilter,
+    saveHideDailyNotesFilter,
+    savePersistedGraphViewMode,
+} from "./utils";
 import { adaptHotkey, fetchSyncPost, getFrontend } from "siyuan";
 import "./index.scss";
-import { getSetting } from "./settings";
 import { initEChart, resize } from "./renderer";
 import { GRAPH_API_CONF } from "./constants";
 import type { GraphType } from "./types";
@@ -26,16 +35,25 @@ export function initDock() {
             ${i18n.pluginName}
         </div>
         <span class="fn__flex-1 fn__space"></span>
-        <span id="graph_enhance_dailynote" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnHideDN}"><svg id="graph_enhance_dailynote_icon" class="plugin-sample__dock-icon"><use xlink:href="#iconCalendar"></use></svg></span>
-        <span id="graph_enhance_path" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnPath}"><svg class="plugin-sample__dock-icon"><use xlink:href="#iconCode"></use></svg></span>
-        <span id="graph_enhance_global" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnGlobal}"><svg class="plugin-sample__dock-icon"><use xlink:href="#iconLanguage"></use></svg></span>
-        <span id="graph_enhance_neighbor" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnNeighbor}"><svg class="plugin-sample__dock-icon"><use xlink:href="#iconWorkspace"></use></svg></span>
-        <span id="graph_enhance_cross" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnCross}"><svg class="plugin-sample__dock-icon"><use xlink:href="#iconFocus"></use></svg></span>
-        <span id="graph_enhance_ancestor" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnAncestor}"><svg class="plugin-sample__dock-icon"><use xlink:href="#iconGraph"></use></svg></span>
-        <span id="graph_enhance_brother" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnBrother}"><svg class="plugin-sample__dock-icon"><use xlink:href="#iconGlobalGraph"></use></svg></span>
-        <span id="graph_enhance_refresh" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnRefresh}"><svg><use xlink:href="#iconRefresh"></use></svg></span>
-        <span id="graph_enhance_fullscreen" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnFullscreen}"><svg><use xlink:href="#iconFullscreen"></use></svg></span>
-        <span data-type="min" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="Min ${adaptHotkey("⌘W")}"><svg><use xlink:href="#iconMin"></use></svg></span>
+        <span class="plugin-sample__dock-group">
+            <span id="graph_enhance_autofollow" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnDisableAutoFollow}"><svg id="graph_enhance_autofollow_icon" class="plugin-sample__dock-icon"><use xlink:href="#iconAutoFollow"></use></svg></span>
+            <span id="graph_enhance_dailynote" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnHideDN}"><svg id="graph_enhance_dailynote_icon" class="plugin-sample__dock-icon"><use xlink:href="#iconCalendar"></use></svg></span>
+        </span>
+        <span class="plugin-sample__dock-divider" aria-hidden="true"></span>
+        <span class="plugin-sample__dock-group">
+            <span id="graph_enhance_path" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnPath}"><svg class="plugin-sample__dock-icon"><use xlink:href="#iconCode"></use></svg></span>
+            <span id="graph_enhance_global" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnGlobal}"><svg class="plugin-sample__dock-icon"><use xlink:href="#iconLanguage"></use></svg></span>
+            <span id="graph_enhance_neighbor" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnNeighbor}"><svg class="plugin-sample__dock-icon"><use xlink:href="#iconWorkspace"></use></svg></span>
+            <span id="graph_enhance_cross" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnCross}"><svg class="plugin-sample__dock-icon"><use xlink:href="#iconFocus"></use></svg></span>
+            <span id="graph_enhance_ancestor" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnAncestor}"><svg class="plugin-sample__dock-icon"><use xlink:href="#iconGraph"></use></svg></span>
+            <span id="graph_enhance_brother" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnBrother}"><svg class="plugin-sample__dock-icon"><use xlink:href="#iconGlobalGraph"></use></svg></span>
+        </span>
+        <span class="plugin-sample__dock-divider" aria-hidden="true"></span>
+        <span class="plugin-sample__dock-group">
+            <span id="graph_enhance_refresh" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnRefresh}"><svg><use xlink:href="#iconRefresh"></use></svg></span>
+            <span id="graph_enhance_fullscreen" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${i18n.dockBtnFullscreen}"><svg><use xlink:href="#iconFullscreen"></use></svg></span>
+            <span data-type="min" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="Min ${adaptHotkey("⌘W")}"><svg><use xlink:href="#iconMin"></use></svg></span>
+        </span>
     </div>
     <div class="fn__flex-1 plugin-sample__custom-dock">
     <div id="graph_enhance_container" style="position:absolute;width:100%;height:100%;" ></div>
@@ -56,6 +74,10 @@ export function initDock() {
         type: DOCK_TYPE,
         init() {
             this.element.innerHTML = dockHtml;
+
+            document.getElementById("graph_enhance_autofollow")!.onclick = async () => {
+                applyAutoFollowState(!getAutoFollowFilter(), true);
+            };
 
             document.getElementById("graph_enhance_dailynote")!.onclick = async () => {
                 applyDailyNoteState(!getHideDailyNotesFilter(), true);
@@ -126,6 +148,7 @@ export function initDock() {
             const savedGraphType = getPersistedGraphViewMode();
             setGraphType(savedGraphType);
             applyGraphTypeState(savedGraphType);
+            applyAutoFollowState(getAutoFollowFilter());
             applyDailyNoteState(getHideDailyNotesFilter());
 
             initEChart();
@@ -136,14 +159,22 @@ export function initDock() {
                 width: container.offsetWidth,
                 height: container.offsetHeight
             });
-            if (getSetting("autoFollow") === "true" && container.offsetWidth !== 0 && container.offsetHeight !== 0) {
-                plugin.eventBus.off("switch-protyle", autoFollow);
-                plugin.eventBus.on("switch-protyle", autoFollow);
-            } else {
-                plugin.eventBus.off("switch-protyle", autoFollow);
-            }
+            syncAutoFollowSubscription();
         }
     });
+
+    function applyAutoFollowState(isEnabled: boolean, shouldPersist = false) {
+        if (shouldPersist) {
+            saveAutoFollowFilter(isEnabled);
+        }
+
+        document.getElementById("graph_enhance_autofollow")?.setAttribute(
+            "aria-label",
+            isEnabled ? i18n.dockBtnDisableAutoFollow : i18n.dockBtnEnableAutoFollow
+        );
+        toggleDockIconState("graph_enhance_autofollow_icon", isEnabled);
+        syncAutoFollowSubscription(isEnabled);
+    }
 
     function applyDailyNoteState(isHidden: boolean, shouldPersist = false) {
         if (shouldPersist) {
@@ -170,6 +201,16 @@ export function initDock() {
 
     function toggleDockIconState(elementId: string, isActive: boolean) {
         document.getElementById(elementId)?.classList.toggle("plugin-sample__dock-icon--active", isActive);
+    }
+
+    function syncAutoFollowSubscription(isEnabled = getAutoFollowFilter()) {
+        const container = document.getElementById("graph_enhance_container");
+        const isVisible = container !== null && container.offsetWidth !== 0 && container.offsetHeight !== 0;
+
+        plugin.eventBus.off("switch-protyle", autoFollow);
+        if (isEnabled && isVisible) {
+            plugin.eventBus.on("switch-protyle", autoFollow);
+        }
     }
 }
 

--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -23,6 +23,8 @@
   "needStartPointMsg": "need select a note first",
 
   "autoFollow": "automatic follow the opened note",
+  "dockBtnEnableAutoFollow": "Enable Auto Follow",
+  "dockBtnDisableAutoFollow": "Disable Auto Follow",
 
   "dockBtnNeighbor": "Neighbor Graph",
   "dockBtnCross": "V&H Graph",

--- a/src/i18n/zh_CN.json
+++ b/src/i18n/zh_CN.json
@@ -23,6 +23,8 @@
   "needStartPointMsg": "需要先选中一篇笔记",
 
   "autoFollow": "自动跟随打开的文档",
+  "dockBtnEnableAutoFollow": "开启自动跟随",
+  "dockBtnDisableAutoFollow": "关闭自动跟随",
 
   "dockBtnNeighbor": "邻近图",
   "dockBtnCross": "纵横图",

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,4 +1,18 @@
 .plugin-sample {
+  &__dock-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+  }
+
+  &__dock-divider {
+    width: 1px;
+    height: 16px;
+    margin: 0 4px;
+    background: var(--b3-border-color);
+    opacity: 0.7;
+  }
+
   &__dock-icon {
     fill: #5f6368;
     transition: fill 0.2s ease;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,13 @@ export default class GraphEnhancePlugin extends Plugin {
         <path d="M30.5 24h-0.5v-6.5c0-1.93-1.57-3.5-3.5-3.5h-8.5v-4h0.5c0.825 0 1.5-0.675 1.5-1.5v-5c0-0.825-0.675-1.5-1.5-1.5h-5c-0.825 0-1.5 0.675-1.5 1.5v5c0 0.825 0.675 1.5 1.5 1.5h0.5v4h-8.5c-1.93 0-3.5 1.57-3.5 3.5v6.5h-0.5c-0.825 0-1.5 0.675-1.5 1.5v5c0 0.825 0.675 1.5 1.5 1.5h5c0.825 0 1.5-0.675 1.5-1.5v-5c0-0.825-0.675-1.5-1.5-1.5h-0.5v-6h8v6h-0.5c-0.825 0-1.5 0.675-1.5 1.5v5c0 0.825 0.675 1.5 1.5 1.5h5c0.825 0 1.5-0.675 1.5-1.5v-5c0-0.825-0.675-1.5-1.5-1.5h-0.5v-6h8v6h-0.5c-0.825 0-1.5 0.675-1.5 1.5v5c0 0.825 0.675 1.5 1.5 1.5h5c0.825 0 1.5-0.675 1.5-1.5v-5c0-0.825-0.675-1.5-1.5-1.5zM6 30h-4v-4h4v4zM18 30h-4v-4h4v4zM14 8v-4h4v4h-4zM30 30h-4v-4h4v4z"></path>
         </symbol><symbol id="iconFullscreen" viewBox="0 0 32 32">
         <path d="M4 4h8v2h-6v6h-2v-8zM10 26h-6v-6h2v6h6v2zM28 4h-8v2h6v6h2v-8zM22 26v2h8v-8h-2v6h-6z"></path>
+        </symbol><symbol id="iconAutoFollow" viewBox="0 0 32 32">
+        <path d="M25.414 10.586l-8-8c-0.781-0.781-2.047-0.781-2.828 0l-8 8 2.828 2.828 4.586-4.586v11.172c0 3.309 2.691 6 6 6h6v4l6-6-6-6v4h-6c-1.103 0-2-0.897-2-2v-11.172l4.586 4.586 2.828-2.828z"></path>
         </symbol>`);
 
         await this.loadData(STORAGE_NAME);
-        this.saveData(STORAGE_NAME, { ...DEFAULT_SETTINGS, ...this.data[STORAGE_NAME] });
+        const { autoFollow: _, ...storedSettings } = this.data[STORAGE_NAME] ?? {};
+        this.saveData(STORAGE_NAME, { ...DEFAULT_SETTINGS, ...storedSettings });
 
         await this.loadData(GRAPH_STATE_STORAGE_NAME);
         this.saveData(GRAPH_STATE_STORAGE_NAME, normalizeGraphPersistedState(this.data[GRAPH_STATE_STORAGE_NAME]));
@@ -32,3 +35,4 @@ export default class GraphEnhancePlugin extends Plugin {
         console.log("graph-enhance uninstalled");
     }
 }
+

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,5 @@
 import { i18n, plugin, STORAGE_NAME } from "./utils";
 import { Setting, showMessage } from "siyuan";
-import { autoFollow } from "./dock";
 import type { SettingKey } from "./types";
 
 export const DEFAULT_SETTINGS = {
@@ -8,7 +7,6 @@ export const DEFAULT_SETTINGS = {
     ranker: "network-simplex",
     nodesMaximum: "200",
     neighborDepth: "2",
-    autoFollow: "true",
     nodesExclusion: "",
     font: "system-ui",
     fontSize: "12",
@@ -57,21 +55,11 @@ export function settingInit() {
                 ranker: algorithmElement.value,
                 nodesMaximum: nodesMaximumElement.value,
                 neighborDepth: neighborDepthElement.value,
-                autoFollow: autoFollowElement.value,
                 nodesExclusion: nodesExclusionElement.value,
                 font: getFontValue(),
                 fontSize: fontSizeElement.value,
             };
             plugin.saveData(STORAGE_NAME, payload);
-
-
-            if (autoFollowElement.value === "true") {
-                plugin.eventBus.off("switch-protyle", autoFollow);
-                plugin.eventBus.on("switch-protyle", autoFollow);
-            } else {
-                plugin.eventBus.off("switch-protyle", autoFollow);
-            }
-
         }
     });
 
@@ -99,18 +87,6 @@ export function settingInit() {
         createActionElement: () => {
             algorithmElement.value = plugin.data[STORAGE_NAME].ranker;
             return algorithmElement;
-        },
-    });
-
-    const autoFollowElement = document.createElement("select");
-    autoFollowElement.id = "autoFollow";
-    autoFollowElement.add(new Option(i18n.yes, "true"));
-    autoFollowElement.add(new Option(i18n.no, "false"));
-    plugin.setting.addItem({
-        title: i18n.autoFollow,
-        createActionElement: () => {
-            autoFollowElement.value = plugin.data[STORAGE_NAME].autoFollow;
-            return autoFollowElement;
         },
     });
 

--- a/src/styles.d.ts
+++ b/src/styles.d.ts
@@ -1,0 +1,1 @@
+declare module "*.scss";

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,6 @@ export type SettingKey =
     | "ranker"
     | "nodesMaximum"
     | "neighborDepth"
-    | "autoFollow"
     | "nodesExclusion"
     | "font"
     | "fontSize";
@@ -61,6 +60,7 @@ export interface GraphPersistedViewState {
 
 export interface GraphPersistedFiltersState {
     hideDailyNotes: boolean;
+    autoFollow: boolean;
 }
 
 /** Persisted graph runtime state */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,6 +33,7 @@ export function createDefaultGraphPersistedState(): GraphPersistedState {
         },
         filters: {
             hideDailyNotes: false,
+            autoFollow: true,
         },
     };
 }
@@ -47,6 +48,7 @@ export function normalizeGraphPersistedState(state?: GraphPersistedStatePatch): 
         },
         filters: {
             hideDailyNotes: state?.filters?.hideDailyNotes ?? defaultState.filters.hideDailyNotes,
+            autoFollow: state?.filters?.autoFollow ?? defaultState.filters.autoFollow,
         },
     };
 }
@@ -90,5 +92,15 @@ export function getHideDailyNotesFilter(): boolean {
 export function saveHideDailyNotesFilter(hideDailyNotes: boolean): void {
     saveGraphPersistedState({
         filters: { hideDailyNotes },
+    });
+}
+
+export function getAutoFollowFilter(): boolean {
+    return getGraphPersistedState().filters.autoFollow;
+}
+
+export function saveAutoFollowFilter(autoFollow: boolean): void {
+    saveGraphPersistedState({
+        filters: { autoFollow },
     });
 }


### PR DESCRIPTION
This pull request introduces a refactor to move the `autoFollow` setting from the static settings storage to the runtime graph state, making it a part of the dock's filter controls. It updates the persisted state structure, adapts the UI and logic to reflect this change, and adds comprehensive tests to ensure correct behavior. The `autoFollow` setting is not critical, so the migration will discard it.

The most important changes are:

### State Structure & Migration

* Refactored the persisted state structure to include `autoFollow` under `filters` in the runtime state (`graph-enhance-graph-state`), rather than in the static settings (`graph-enhance-config`). The old settings key is removed on startup, and `autoFollow` defaults to enabled. [[1]](diffhunk://#diff-117f37747a92e8cc9cbd662cd90826dcd745d3c7106ff199df80c8ac08497b7eL8-R10) [[2]](diffhunk://#diff-117f37747a92e8cc9cbd662cd90826dcd745d3c7106ff199df80c8ac08497b7eR22) [[3]](diffhunk://#diff-117f37747a92e8cc9cbd662cd90826dcd745d3c7106ff199df80c8ac08497b7eL31-R33) [[4]](diffhunk://#diff-117f37747a92e8cc9cbd662cd90826dcd745d3c7106ff199df80c8ac08497b7eL40-R49) [[5]](diffhunk://#diff-d88e65f56079eff48d6b092d57fb8c9be81f913cdb64b55b0b1012cdae90a029R1-R73)

### UI & Dock Controls

* Added an "Auto Follow" toggle button to the dock UI, grouped with other filter controls, and updated the UI to reflect the current state. The button's label and active state are dynamically updated. [[1]](diffhunk://#diff-5f2748b97991b4e0cf2b2d1794ad1bb4e8be45f113a71bf43e25ee34a5d09c98R38-R56) [[2]](diffhunk://#diff-5f2748b97991b4e0cf2b2d1794ad1bb4e8be45f113a71bf43e25ee34a5d09c98R78-R81) [[3]](diffhunk://#diff-5f2748b97991b4e0cf2b2d1794ad1bb4e8be45f113a71bf43e25ee34a5d09c98R151)

### Logic & Event Handling

* Implemented handler logic for the auto follow toggle, including state persistence and event bus registration/unregistration when toggled. [[1]](diffhunk://#diff-5f2748b97991b4e0cf2b2d1794ad1bb4e8be45f113a71bf43e25ee34a5d09c98R78-R81) [[2]](diffhunk://#diff-5f2748b97991b4e0cf2b2d1794ad1bb4e8be45f113a71bf43e25ee34a5d09c98R151)

### Utilities & Helpers

* Added `getAutoFollowFilter` and `saveAutoFollowFilter` helpers for reading and writing the filter state, and updated all relevant utility functions and tests to support the new structure. [[1]](diffhunk://#diff-3c616be935d4f3f12995ccdc0d101840c0bb76665a29c61a090a71ac9be6b6b6R4-R12) [[2]](diffhunk://#diff-3c616be935d4f3f12995ccdc0d101840c0bb76665a29c61a090a71ac9be6b6b6L52-R54) [[3]](diffhunk://#diff-3c616be935d4f3f12995ccdc0d101840c0bb76665a29c61a090a71ac9be6b6b6L62-R64) [[4]](diffhunk://#diff-3c616be935d4f3f12995ccdc0d101840c0bb76665a29c61a090a71ac9be6b6b6L80-R86) [[5]](diffhunk://#diff-3c616be935d4f3f12995ccdc0d101840c0bb76665a29c61a090a71ac9be6b6b6L92-R95) [[6]](diffhunk://#diff-3c616be935d4f3f12995ccdc0d101840c0bb76665a29c61a090a71ac9be6b6b6L106-R131)

### Tests

* Updated and expanded tests to verify the new state structure, UI behavior, and migration logic, including tests for dock initialization, toggling, and state persistence. [[1]](diffhunk://#diff-3d62bee7ae77578887d37c30727229a574d39b7e3c7018d062a155171ad8e52bR7-R20) [[2]](diffhunk://#diff-3d62bee7ae77578887d37c30727229a574d39b7e3c7018d062a155171ad8e52bR44-R45) [[3]](diffhunk://#diff-3d62bee7ae77578887d37c30727229a574d39b7e3c7018d062a155171ad8e52bL50-L67) [[4]](diffhunk://#diff-3d62bee7ae77578887d37c30727229a574d39b7e3c7018d062a155171ad8e52bR92-R95) [[5]](diffhunk://#diff-3d62bee7ae77578887d37c30727229a574d39b7e3c7018d062a155171ad8e52bR112-R190)

These changes together ensure that `autoFollow` is now a runtime, per-graph-view filter, with a more intuitive UI and robust state handling.

Closes #48 